### PR TITLE
Prevent HistoryGraph from logging TypeError syslog

### DIFF
--- a/package/contents/ui/HistoryGraph.qml
+++ b/package/contents/ui/HistoryGraph.qml
@@ -38,7 +38,7 @@ Item {
             width: historyGraph.width / graphGranularity
             height: historyGraph.height * graphItemPercent
             x: 0
-            y: parent.height - height
+            y: parent === null ? 0 : parent.height - height
             color: barColor
             radius: 3
         }


### PR DESCRIPTION
On a recent plasma desktop (5.19.3), I get the below syslog filling out my logs:
plasmashell[112996]: file:///usr/local/share/plasma/plasmoids/org.kde.resourcesMonitor/contents/ui/HistoryGraph.qml:41: TypeError: Cannot read property 'height' of null
This patch clears it out.